### PR TITLE
configure AWS Kibana

### DIFF
--- a/Kibana/README.md
+++ b/Kibana/README.md
@@ -1,0 +1,2 @@
+This will deploy two AWS-managed ES domains (test and live), with Kibana on a public IP and and access policy allowing only the k8s clusters (and the OIDc proxy that will be running on them)
+To redeploy, just `terraform plan && terraform apply`

--- a/Kibana/main.tf
+++ b/Kibana/main.tf
@@ -1,0 +1,116 @@
+terraform {
+  backend "s3" {
+    bucket = "cloud-platform-kibana"
+    region = "eu-west-1"
+    key    = "terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "global" {
+  backend = "s3"
+
+  config {
+    bucket = "cloud-platform-kibana"
+    region = "eu-west-1"
+    key    = "terraform.tfstate"
+  }
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+resource "aws_elasticsearch_domain" "test" {
+  domain_name           = "${var.test_domain}"
+  elasticsearch_version = "6.2"
+
+  cluster_config {
+    instance_type = "t2.small.elasticsearch"
+  }
+
+  ebs_options {
+    ebs_enabled = "true"
+    volume_type = "standard"
+    volume_size = "16"
+  }
+
+  advanced_options {
+    "rest.action.multi.allow_explicit_index" = "true"
+  }
+
+  access_policies = <<CONFIG
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "es:*",
+      "Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.test_domain}/*",
+      "Condition": {
+        "IpAddress": {
+          "aws:SourceIp": ${jsonencode(keys(var.allowed_test_ips))}
+        }
+      }
+    }
+  ]
+}
+CONFIG
+
+  snapshot_options {
+    automated_snapshot_start_hour = 23
+  }
+
+  tags {
+    Domain = "${var.test_domain}"
+  }
+}
+
+resource "aws_elasticsearch_domain" "live" {
+  domain_name           = "${var.live_domain}"
+  elasticsearch_version = "6.2"
+
+  cluster_config {
+    instance_type = "m4.large.elasticsearch"
+  }
+
+  ebs_options {
+    ebs_enabled = "true"
+    volume_type = "standard"
+    volume_size = "32"
+  }
+
+  advanced_options {
+    "rest.action.multi.allow_explicit_index" = "true"
+  }
+
+  access_policies = <<CONFIG
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "es:*",
+      "Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.live_domain}/*",
+      "Condition": {
+        "IpAddress": {
+          "aws:SourceIp": ${jsonencode(keys(var.allowed_live_ips))}
+        }
+      }
+    }
+  ]
+}
+CONFIG
+
+  snapshot_options {
+    automated_snapshot_start_hour = 23
+  }
+
+  tags {
+    Domain = "${var.live_domain}"
+  }
+}

--- a/Kibana/main.tf
+++ b/Kibana/main.tf
@@ -30,7 +30,7 @@ resource "aws_elasticsearch_domain" "test" {
   ebs_options {
     ebs_enabled = "true"
     volume_type = "gp2"
-    volume_size = "16"
+    volume_size = "32"
   }
 
   advanced_options {
@@ -78,7 +78,7 @@ resource "aws_elasticsearch_domain" "live" {
   ebs_options {
     ebs_enabled = "true"
     volume_type = "gp2"
-    volume_size = "32"
+    volume_size = "320"
   }
 
   advanced_options {

--- a/Kibana/main.tf
+++ b/Kibana/main.tf
@@ -29,7 +29,7 @@ resource "aws_elasticsearch_domain" "test" {
 
   ebs_options {
     ebs_enabled = "true"
-    volume_type = "standard"
+    volume_type = "gp2"
     volume_size = "16"
   }
 
@@ -77,7 +77,7 @@ resource "aws_elasticsearch_domain" "live" {
 
   ebs_options {
     ebs_enabled = "true"
-    volume_type = "standard"
+    volume_type = "gp2"
     volume_size = "32"
   }
 

--- a/Kibana/variables.tf
+++ b/Kibana/variables.tf
@@ -1,0 +1,32 @@
+variable "test_domain" {
+  default = "cloud-platform-test"
+}
+
+# for clusters, allow all 3 NAT GW IPs
+variable "allowed_test_ips" {
+  type = "map"
+
+  default = {
+    "81.134.202.29/32"  = "office"
+    "92.27.71.208/32"   = "ollie"
+    "88.98.227.149/32"  = "raz"
+    "54.229.250.233/32" = "test-1-a"
+    "54.229.139.68/32"  = "test-1-b"
+    "34.246.149.106/32" = "test-1-c"
+  }
+}
+
+variable "live_domain" {
+  default = "cloud-platform-live"
+}
+
+variable "allowed_live_ips" {
+  type = "map"
+
+  default = {
+    "81.134.202.29/32"  = "office"
+    "52.17.133.167/32"  = "live-0-a"
+    "34.247.134.240/32" = "live-0-b"
+    "34.251.93.81/32"   = "live-0-c"
+  }
+}


### PR DESCRIPTION
The PR creates two AWS managed ES+Kibana instances, test&live; this 
closes https://github.com/ministryofjustice/cloud-platform/issues/284

As per https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-limits.html, there are limits to be aware for small instances, eg small is<35G storage and <10M payload