### PR TITLE
Defined instance count

### DIFF
--- a/Kibana/main.tf
+++ b/Kibana/main.tf
@@ -25,6 +25,7 @@ resource "aws_elasticsearch_domain" "test" {
 
   cluster_config {
     instance_type = "t2.small.elasticsearch"
+    instance_count = "3"
   }
 
   ebs_options {
@@ -73,6 +74,7 @@ resource "aws_elasticsearch_domain" "live" {
 
   cluster_config {
     instance_type = "m4.large.elasticsearch"
+    instance_count = "3"
   }
 
   ebs_options {


### PR DESCRIPTION
Defined the instance count for both ES Clusters to "3" to match the manual changes made in AWS GUI.