### PR TITLE
Add audit elasticsearch cluster

### DIFF
--- a/Kibana/README.md
+++ b/Kibana/README.md
@@ -1,2 +1,2 @@
-This will deploy two AWS-managed ES domains (test and live), with Kibana on a public IP and and access policy allowing only the k8s clusters (and the OIDc proxy that will be running on them)
+This will deploy three AWS-managed ES domains (test, live and audit), with Kibana on a public IP and and access policy allowing only the k8s clusters (and the OIDc proxy that will be running on them)
 To redeploy, just `terraform plan && terraform apply`

--- a/Kibana/main.tf
+++ b/Kibana/main.tf
@@ -116,3 +116,52 @@ CONFIG
     Domain = "${var.live_domain}"
   }
 }
+
+resource "aws_elasticsearch_domain" "audit" {
+  domain_name           = "${var.audit_domain}"
+  elasticsearch_version = "6.2"
+
+  cluster_config {
+    instance_type = "m4.large.elasticsearch"
+    instance_count = "2"
+  }
+
+  ebs_options {
+    ebs_enabled = "true"
+    volume_type = "gp2"
+    volume_size = "320"
+  }
+
+  advanced_options {
+    "rest.action.multi.allow_explicit_index" = "true"
+  }
+
+  access_policies = <<CONFIG
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "es:*",
+      "Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.audit_domain}/*",
+      "Condition": {
+        "IpAddress": {
+          "aws:SourceIp": ${jsonencode(keys(var.allowed_audit_ips))}
+        }
+      }
+    }
+  ]
+}
+CONFIG
+
+  snapshot_options {
+    automated_snapshot_start_hour = 23
+  }
+
+  tags {
+    Domain = "${var.audit_domain}"
+  }
+}

--- a/Kibana/variables.tf
+++ b/Kibana/variables.tf
@@ -27,3 +27,18 @@ variable "allowed_live_ips" {
     "34.251.93.81/32"   = "live-0-c"
   }
 }
+
+variable "audit_domain" {
+  default = "cloud-platform-audit"
+}
+
+variable "allowed_audit_ips" {
+  type = "map"
+
+  default = {
+    "81.134.202.29/32"  = "office"
+    "52.17.133.167/32"  = "live-0-a"
+    "34.247.134.240/32" = "live-0-b"
+    "34.251.93.81/32"   = "live-0-c"
+  }
+}


### PR DESCRIPTION
connects to https://github.com/ministryofjustice/cloud-platform/issues/308
**WHAT**
This PR contains the required Terraform config to create a new Elasticsearch cluster. It also contains an amendment to the readme.

**WHY**
To create an 'audit' cluster for the Cloud-platform team - this will allow us to store and search audit data. 