### PR TITLE
Add Cloudtrail terraform scripts

### DIFF
--- a/Cloudtrail/main.tf
+++ b/Cloudtrail/main.tf
@@ -7,7 +7,7 @@ terraform {
 }
 
 provider "aws" {
-    region = "us-east-1"
+    region = "eu-west-1"
 }
 
 data "aws_caller_identity" "current" {}

--- a/Cloudtrail/main.tf
+++ b/Cloudtrail/main.tf
@@ -1,0 +1,86 @@
+terraform {
+  backend "s3" {
+    bucket = "cloud-platform-cloudtrail-tf-state"
+    region = "eu-west-1"
+    key    = "terraform.tfstate"
+  }
+}
+
+provider "aws" {
+    region = "us-east-1"
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_cloudtrail" "cloud-platform-cloudtrail" {
+  name                          = "cp-cloudtrail"
+  s3_bucket_name                = "${aws_s3_bucket.cloudtrail-bucket.id}"
+  include_global_service_events = true
+  is_multi_region_trail         = true
+  enable_log_file_validation    = true
+  tags {
+        business-unit           = "${var.business-unit}"
+        owner                   = "${var.team_name}"
+        infrastructure-support  = "${var.infrastructure-support}"
+    }
+}
+resource "aws_s3_bucket" "cloudtrail-bucket" {
+  bucket        = "cloud-platform-cloudtrail-moj"
+  force_destroy = false
+  tags {
+        business-unit           = "${var.business-unit}"
+        owner                   = "${var.team_name}"
+        infrastructure-support  = "${var.infrastructure-support}"
+    }
+  lifecycle_rule {
+    id                                     = "logs-transition"
+    prefix                                 = ""
+    abort_incomplete_multipart_upload_days = 7
+    enabled                                = true
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 60
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days = 365
+    }
+  }
+  
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AWSCloudTrailAclCheck",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
+            "Action": "s3:GetBucketAcl",
+            "Resource": "arn:aws:s3:::cloud-platform-cloudtrail-moj"
+        },
+        {
+            "Sid": "AWSCloudTrailWrite",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::cloud-platform-cloudtrail-moj/*",
+            "Condition": {
+                "StringEquals": {
+                    "s3:x-amz-acl": "bucket-owner-full-control"
+                }
+            }
+        }
+    ]
+}
+POLICY
+}

--- a/Cloudtrail/variables.tf
+++ b/Cloudtrail/variables.tf
@@ -1,0 +1,12 @@
+variable "team_name" {
+}
+variable "business-unit" {
+  description = " Area of the MOJ responsible for the service"
+  default     = "mojdigital"
+}
+variable "infrastructure-support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form <team-name> (<team-email>)"
+}
+variable "terraform_bucket_name" {
+    default   = "cloud-platform-cloudtrail-tf-state"
+}

--- a/Cloudtrail/variables.tf
+++ b/Cloudtrail/variables.tf
@@ -1,12 +1,18 @@
-variable "team_name" {
-}
+variable "team_name" {}
+
 variable "business-unit" {
   description = " Area of the MOJ responsible for the service"
   default     = "mojdigital"
 }
+
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form <team-name> (<team-email>)"
 }
+
 variable "terraform_bucket_name" {
-    default   = "cloud-platform-cloudtrail-tf-state"
+  default = "cloud-platform-cloudtrail-tf-state"
+}
+
+variable "cloudtrail_bucket_name" {
+    default = "cp-cloudtrail-bucket"
 }


### PR DESCRIPTION
connects to https://github.com/ministryofjustice/cloud-platform/issues/307

**WHAT**
This PR contains the Terraform file that includes the creation of a Cloudtrail instance with an S3 bucket for log storage. All environments have been included and I've applied a lifecycle rule with relevant tagging. 

**WHY**
This connects to issue https://github.com/ministryofjustice/cloud-platform/issues/307. It will be applied to the Integration account. This will enable Cloudtrail for all regions and host in an S3 bucket. 