### PR TITLE
Amend IAM policy for ES Audit Cluster

### DIFF
--- a/Kibana/main.tf
+++ b/Kibana/main.tf
@@ -149,7 +149,20 @@ resource "aws_elasticsearch_domain" "audit" {
       "Principal": {
         "AWS": "*"
       },
-      "Action": "es:*",
+      "Action":[ "es:AddTags",
+                "es:ESHttpHead",
+                "es:DescribeElasticsearchDomain",
+                "es:ESHttpPost",
+                "es:ESHttpGet",
+                "es:DescribeElasticsearchDomainConfig",
+                "es:ListTags",
+                "es:DescribeElasticsearchDomains",
+                "es:ESHttpPut",
+                "es:ListDomainNames",
+                "es:ListElasticsearchInstanceTypes",
+                "es:DescribeElasticsearchInstanceTypeLimits",
+                "es:ListElasticsearchVersions"
+      ],
       "Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${local.audit_domain}/*",
       "Condition": {
         "IpAddress": {

--- a/Kibana/main.tf
+++ b/Kibana/main.tf
@@ -157,7 +157,6 @@ resource "aws_elasticsearch_domain" "audit" {
                 "es:DescribeElasticsearchDomainConfig",
                 "es:ListTags",
                 "es:DescribeElasticsearchDomains",
-                "es:ESHttpPut",
                 "es:ListDomainNames",
                 "es:ListElasticsearchInstanceTypes",
                 "es:DescribeElasticsearchInstanceTypeLimits",


### PR DESCRIPTION
Audit Cluster 
This change to the iam policy prevents the following the actions (including index deletion) using the default policy used by all users:

UpdateElasticsearchDomainConfig
DeleteElasticsearchDomain
RemoveTags
CreateElasticsearchDomain
DeleteElasticsearchServiceRole
ESHttpDelete

