### PR TITLE
Allow es:ESHttpPut for Elasticsearch

### DIFF
--- a/Kibana/main.tf
+++ b/Kibana/main.tf
@@ -154,6 +154,7 @@ resource "aws_elasticsearch_domain" "audit" {
                 "es:DescribeElasticsearchDomain",
                 "es:ESHttpPost",
                 "es:ESHttpGet",
+                "es:ESHttpPut",
                 "es:DescribeElasticsearchDomainConfig",
                 "es:ListTags",
                 "es:DescribeElasticsearchDomains",


### PR DESCRIPTION
This is required by fluentd in order to apply the index templates used in audit log collection.