### PR TITLE
Billing alarms email notification on AWS account

### DIFF
--- a/Billing/README.md
+++ b/Billing/README.md
@@ -1,0 +1,14 @@
+To run this into an AWS account, use the AWS cli via the below command:
+
+```
+aws budgets create-budget --cli-input-json file://[file location]/cloudplatform-budget.json --account-id=[account number to create budget in] --profile=[AWS cli profile]
+```
+
+You'll need to run this for every account you want to create a budget for.
+
+```
+You can delete this budget with the below command:
+aws budgets delete-budget --account-id=[account number to delete budget from] --profile=[AWS cli profile] --budget-name 'Monthly AWS Budget'
+```
+
+Account profiles are explained on the LAA Migration Confluence pages under AWS > Identity & Access Management.

--- a/Billing/cloudplatform-budget.json
+++ b/Billing/cloudplatform-budget.json
@@ -1,0 +1,94 @@
+{
+    "AccountId": "754256621582",
+    "Budget": {
+        "BudgetName": "Monthly AWS Budget (cloud-platform-clusters)",
+        "BudgetLimit": {
+            "Amount": "5000", 
+            "Unit": "USD"
+        },
+        "CostTypes": {
+            "IncludeTax":  true,
+            "IncludeSubscription": true,
+            "UseBlended": false
+        },
+        "TimeUnit": "MONTHLY",
+        "TimePeriod": {
+            "Start": "1970-01-01T00:00:00", 
+            "End": "2040-01-01T00:00:00"
+        },
+        "BudgetType": "COST"
+    },
+    "NotificationsWithSubscribers": [
+        {
+            "Notification": {
+                 "NotificationType": "ACTUAL",
+                "ComparisonOperator": "GREATER_THAN",
+                "Threshold": 25,
+                 "ThresholdType": "PERCENTAGE"
+            },
+            "Subscribers": [
+                {
+                    "SubscriptionType": "EMAIL",
+                     "Address": "platforms@digital.justice.gov.uk"
+                 }
+             ]
+         },
+        { 
+            "Notification": { 
+                "NotificationType": "ACTUAL",
+                "ComparisonOperator": "GREATER_THAN",
+                "Threshold": 50,
+                "ThresholdType": "PERCENTAGE"
+            },
+            "Subscribers": [
+                { 
+                    "SubscriptionType": "EMAIL",
+                     "Address": "platforms@digital.justice.gov.uk"
+                }
+            ]
+        }
+        ,
+        {
+            "Notification": {
+                "NotificationType": "ACTUAL",
+                "ComparisonOperator": "GREATER_THAN",
+                "Threshold": 75,
+                "ThresholdType": "PERCENTAGE"
+            },
+            "Subscribers": [
+                {
+                    "SubscriptionType": "EMAIL",
+                    "Address": "platforms@digital.justice.gov.uk"
+                }
+            ]
+        },
+        {
+            "Notification": {
+                "NotificationType": "ACTUAL",
+                "ComparisonOperator": "GREATER_THAN",
+                "Threshold": 100,
+                "ThresholdType": "PERCENTAGE"
+            },
+            "Subscribers": [
+                {
+                    "SubscriptionType": "EMAIL",
+                    "Address": "platforms@digital.justice.gov.uk"
+                }
+            ]
+        },
+        {
+            "Notification": {
+                "NotificationType": "ACTUAL",
+                "ComparisonOperator": "GREATER_THAN",
+                "Threshold": 125,
+                "ThresholdType": "PERCENTAGE"
+            },
+            "Subscribers": [
+                {
+                    "SubscriptionType": "EMAIL",
+                    "Address": "platforms@digital.justice.gov.uk"
+                }
+            ]
+         }
+    ] 
+}


### PR DESCRIPTION
connects to https://github.com/ministryofjustice/cloud-platform/issues/455

**WHAT**
1. `Billing/cloudplatform-budget.json` will enable a billing trigger that informs `platforms@digital.justice.gov.uk` when we hit a certain threshold. 
2. README containing `how to's`.

**WHY**
1. This will allow the team to keep an eye on how much is being spent in a given account. 
2. To allow engineers to replicate install. 