### PR TITLE
Add S3 state store creation terraform

### DIFF
--- a/s3-state-store/main.tf
+++ b/s3-state-store/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket = "cloud-platform-s3-terraform-state"
+    region = "eu-west-1"
+    key    = "terraform.tfstate"
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}

--- a/s3-state-store/s3.tf
+++ b/s3-state-store/s3.tf
@@ -1,0 +1,17 @@
+resource "aws_s3_bucket" "kops_state" {
+  bucket = "${var.kops_bucket_name}"
+  region = "${var.region}"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}

--- a/s3-state-store/variables.tf
+++ b/s3-state-store/variables.tf
@@ -1,0 +1,7 @@
+variable "region" {
+  default = "eu-west-1"
+}
+
+variable "kops_bucket_name" {
+  default = "cloud-platform-kops-terraform-state"
+  }


### PR DESCRIPTION
connects to https://github.com/ministryofjustice/cloud-platform/issues/457

**WHAT**
**1.** The PR contains the terraform configuration to create a generic kops state store in the Cloud Platform account. 

**WHY**
**1.** To create a cluster agnostic kops state store to reference for the future "cluster creation pipeline"

**NOTES**
I believe this repo has ended up as a bit of a mis-match of configuration. I have created a ticket to refactor the terraform dirs in this repo:
https://github.com/ministryofjustice/cloud-platform/issues/472