### PR TITLE
Setup a new subdomain in the cloud-platform account

### DIFF
--- a/Route53/README.md
+++ b/Route53/README.md
@@ -1,0 +1,40 @@
+# Setup a new subdomain in the cloud-platform account
+
+Terraform created to manage delegated hosted zones in the cloud-platfoem-aws account.
+
+
+### Set environment variables.
+
+```
+$ export AWS_PROFILE=<profile_name>
+$ export KOPS_STATE_STORE=s3://route53-terraform
+```
+
+### Add new Hosted Zone
+
+Edit `variables.tf` with new hosted zone name
+
+To run you need to execute the below in the terraform directory:
+
+```
+$ Terraform init
+$ Terraform plan
+$ Terraform apply
+```
+
+
+
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| rroute53_domain | name of new hosted zone | string | - | yes |
+
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| name_servers | Name Servers of new Hosted Zone |
+| zone_id | AWS Zone ID of new Hosted Zone |

--- a/Route53/README.md
+++ b/Route53/README.md
@@ -22,9 +22,6 @@ $ Terraform plan
 $ Terraform apply
 ```
 
-
-
-
 ### Inputs
 
 | Name | Description | Type | Default | Required |
@@ -38,3 +35,8 @@ $ Terraform apply
 |------|-------------|
 | name_servers | Name Servers of new Hosted Zone |
 | zone_id | AWS Zone ID of new Hosted Zone |
+
+
+Add the name servers for the created subdomain to the parent domain within the parent MOJ AWS account.
+
+For more information [click here](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingNewSubdomain.html) for the AWS offical documentation 

--- a/Route53/dns.tf
+++ b/Route53/dns.tf
@@ -1,0 +1,4 @@
+resource "aws_route53_zone" "hosted_zones" {
+  count = "${length(split(",", var.route53_domain))}"
+  name = "${element(split(",", var.route53_domain), count.index)}"
+}

--- a/Route53/main.tf
+++ b/Route53/main.tf
@@ -1,0 +1,12 @@
+terraform {
+backend "s3" {
+  bucket = "route53-terraform"
+  region = "eu-west-1"
+  key    = "terraform.tfstate"
+  }
+}
+provider "aws" {
+  region = "${var.aws_region}"
+  } 
+
+

--- a/Route53/outputs.tf
+++ b/Route53/outputs.tf
@@ -1,0 +1,6 @@
+output "name_servers" {
+  value = "${aws_route53_zone.hosted_zones.*.name_servers}"
+}
+output "zone_id" {
+  value = "${aws_route53_zone.hosted_zones.*.zone_id}"
+}

--- a/Route53/variables.tf
+++ b/Route53/variables.tf
@@ -1,0 +1,8 @@
+variable "route53_domain" {
+default = "cloud-platform.justice.gov.uk"
+}
+
+variable "aws_region" {
+  description = "Ireland"
+  default     = "eu-west-1"
+}


### PR DESCRIPTION
WHAT
We need to move off dsd.io and we also want to move to shorter, more friendly hostnames for our clusters.
We would like to have cloud-platform.justice.gov.uk delegated to the new account so that we can then use live-x.cloud-platform.justice.gov.uk for individual clusters.

WHY
Using Terraform we can manage config for all new creations in the CP AWS account